### PR TITLE
fix package_openrb_index.json

### DIFF
--- a/package_openrb_index.json
+++ b/package_openrb_index.json
@@ -16,7 +16,7 @@
           "url": "https://github.com/ROBOTIS-GIT/OpenRB-150/raw/master/OpenRB-150.zip",
           "archiveFileName": "OpenRB-150.zip",
           "checksum": "SHA-256:cfdd0f75b25621dab6af834c0d8ef9e5e675ccd9554b066a376a5e76f3888b81",
-          "size": "835451",
+          "size": "835246",
           "boards": [
             {
               "name": "OpenRB-150"
@@ -32,7 +32,7 @@
             {
               "packager": "arduino",
               "name": "bossac",
-              "version": "1.8.0-48-gb176eee"
+              "version": "1.7.0-arduino3"
             },
             {
               "packager": "arduino",


### PR DESCRIPTION
I could not install OpenRB-150 Board in the board manager on Arduino IDE, and I fixed the json file.